### PR TITLE
Add ProviderData in scope

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 use fiberplane_pdk::prelude::*;
+use fiberplane_pdk::provider_data::ProviderData;
 use serde::{Deserialize, Serialize};
 
 /// Query type for the provider's showcase.


### PR DESCRIPTION
The tutorial forgot to make the user add the ProviderData trait in scope

This should be a ticket to the PDK as it should be part of the prelude from the beginning
